### PR TITLE
Remove unused `filter-obj` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "all-node-versions": "^13.0.1",
-        "filter-obj": "^6.1.0",
         "is-plain-obj": "^4.1.0",
         "normalize-node-version": "^14.0.1",
         "path-exists": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   },
   "dependencies": {
     "all-node-versions": "^13.0.1",
-    "filter-obj": "^6.1.0",
     "is-plain-obj": "^4.1.0",
     "normalize-node-version": "^14.0.1",
     "path-exists": "^5.0.0",


### PR DESCRIPTION
**Which problem is this pull request solving?**

`filter-obj` is listed in `dependencies` but nothing in the package uses it, so every
install resolves and downloads it for nothing.

**List other issues or pull requests related to this problem**

No existing issue. The same leftover declaration is in `all-node-versions` (https://github.com/ehmicky/all-node-versions/pull/45) and
`normalize-node-version` (https://github.com/ehmicky/normalize-node-version/pull/43), where I have opened the same change. Since these three
depend on one another, `filter-obj` only leaves a consumer's tree once all three are
merged.

**Describe the solution you've chosen**

Removed the `filter-obj` entry from `dependencies` and let `npm install` update
`package-lock.json`. No source file changed.

The only import was `import { excludeKeys } from 'filter-obj'` in `src/options.js`. It was
removed in b04dc8c ("Reduce npm package size", 2022-10-16), and the dependency declaration
stayed behind.

Verified at 7a036b1 on Node 20.20.0:

- `git grep filter-obj` matches `package.json` and `package-lock.json` and nothing else.
  Searching for `filterObj` and `filter_obj` finds nothing, so it is not imported under
  another name.
- `npm test` before the change: 26 tests passed, exit 0.
- `npm test` after the change: 26 tests passed, exit 0.

`npm test` runs prettier, eslint, jscpd and the type check in the same task, so those ran
on both sides as well.

**Describe alternatives you've considered**

Moving it to `devDependencies`. Nothing references it there either, including the tests,
so there is nothing to keep it for.

**Checklist**

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [ ] I have added tests (we are enforcing 100% test coverage). No code was added or
      changed, so there is nothing new to cover and coverage is unaffected.
- [ ] I have added documentation in the `README.md`, the `docs` directory (if any). Not
      applicable: no API, option or behaviour change.
- [ ] The status checks are successful (continuous integration). I cannot tick this before
      opening the pull request; I will confirm once CI has run.
